### PR TITLE
Can't generate Chinese fonts in  html pictures

### DIFF
--- a/sphinxcontrib/tikz.py
+++ b/sphinxcontrib/tikz.py
@@ -191,6 +191,7 @@ DOC_HEAD = r'''
 \usepackage[utf8]{inputenc}
 \usepackage{amsmath}
 \usepackage{pgfplots}
+\usepackage{xeCJK}
 \usetikzlibrary{%s}
 \pagestyle{empty}
 '''


### PR DESCRIPTION
when run in sphinx `make latex` is can generate a picture with Chinese Because in the ``` source/conf.py```  ``` latex_elements```  define \usepackage{XeCJK}
when run in sphinx `make html` is can't generate a picture with Chinese, Because no  \usepackage{XeCJK} was include.